### PR TITLE
Fix: preview pages not working #34

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -54,12 +54,11 @@ jobs:
         with:
           path: |
             .next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx', 'nextjs.yml') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx', 'next.config.js') }}
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Run Lint
         run: ${{ steps.detect-package-manager.outputs.runner }} lint
-      # change basePath for PRs and the preview build
       - name: Build with Next.js
         run: |
           touch .env

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dev": "next dev",
     "build": "cross-env NODE_ENV=development next build && next export",
     "build-prod": "cross-env NODE_ENV=production next build && next export",
-    "build-map": "next build -p /map && next export",
     "start": "next start",
     "lint": "prettier . '**/*.{js,jsx,ts}' --check && next lint"
   },


### PR DESCRIPTION
The basePath in next.config.js is not working with preview pages. The scripts in the preview pages are always point to /reactgeoda, not /reactgeoda/preview/pr-xxx.