### PR TITLE
Chore: add build for 3rd party

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,9 +7,24 @@ const nextConfig = {
   basePath: process.env.BASE_PATH ?? '/reactgeoda',
   images: {unoptimized: true},
   generateBuildId: async () => 'reactgeoda-v0.1',
-  webpack: config => {
+  webpack: (config, options) => {
     config.optimization.splitChunks = false;
     config.optimization.minimize = isProduction;
+    if (!options.dev) {
+      // when build production for 3rd party e.g. data-and-lab, remove hash id from file name
+      config.output.filename = config.output.filename.replace('-[contenthash]', '');
+      config.output.chunkFilename = config.output.chunkFilename.replace('.[contenthash]', '');
+      config.output.webassemblyModuleFilename = config.output.chunkFilename.replace('.[modulehash]', '');
+      const CopyFilePlugin = config.plugins.find(item => item.constructor.name === 'CopyFilePlugin');
+      if (CopyFilePlugin) {
+        CopyFilePlugin.name = CopyFilePlugin.name.replace('-[hash]', '');
+      }
+      const NextMiniCssExtractPlugin = config.plugins.find(item => item.constructor.name === 'NextMiniCssExtractPlugin');
+      if (NextMiniCssExtractPlugin) {
+        NextMiniCssExtractPlugin.options.filename = NextMiniCssExtractPlugin.options.filename.replace('[contenthash]', '[name]');
+        NextMiniCssExtractPlugin.options.chunkFilename = NextMiniCssExtractPlugin.options.chunkFilename.replace('[contenthash]', '[name]');
+      }
+    }
     return config;
   }
 };

--- a/package.json
+++ b/package.json
@@ -3,11 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "cross-env NODE_ENV=development next build && next export",
+    "dev": "cross-env BASE_PATH='' next dev",
+    "build": "cross-env NODE_ENV=development BASE_PATH='' next build && next export",
     "build-prod": "cross-env NODE_ENV=production next build && next export",
-    "build-map": "next build -p /map && next export",
-    "start": "next start",
+    "start": "cross-env BASE_PATH='' next start",
     "lint": "prettier . '**/*.{js,jsx,ts}' --check && next lint"
   },
   "dependencies": {


### PR DESCRIPTION
When building reactgeoda for 3rd party e.g. GeoDa desktop app or Data-and-Lab website, we need to remove the hash ids that are attached to each compiled file name (e.g. /_app-68579074e799b68944fe.js). The hash ids brings complexity when integrating the components from reactgeoda to other apps. 

This PR will try to remove the hash ids when running `yarn build` for 3rd party usage. 

@dpeachpeach David, please help to confirm it in data-and-lab repo. You can run `git checkout misc-build-for-3rdparty` under the reactgeoda submodule. Thanks!