### PR TITLE
[Fix] Failed to create table in duckdb

### DIFF
--- a/geoda-ai/__test__/actions/file-actions.test.ts
+++ b/geoda-ai/__test__/actions/file-actions.test.ts
@@ -81,7 +81,7 @@ describe('File Actions', () => {
     const actionHistory = await reduxThunkTester.getActionHistoryAsync(); // need to wait async thunk (all inner dispatch)
     expect(actionHistory).toContainEqual({
       type: 'SET_OPEN_FILE_MODAL_ERROR',
-      payload: 'Dataset already exists in the project'
+      payload: 'Dataset already exists in the project.'
     });
   });
 

--- a/geoda-ai/src/actions/file-actions.ts
+++ b/geoda-ai/src/actions/file-actions.ts
@@ -52,7 +52,7 @@ export const loadDroppedFilesAsync =
           existingDatasetNames.includes(dataset.fileName)
         );
         if (datasetAlreadyExist) {
-          throw new Error('Dataset already exists in the project');
+          throw new Error('Dataset already exists in the project.');
         }
       }
       // check if there is a shapefile

--- a/geoda-ai/src/hooks/use-duckdb.ts
+++ b/geoda-ai/src/hooks/use-duckdb.ts
@@ -233,7 +233,9 @@ export class DuckDB {
           await conn.query(`UPDATE "${tableName}" SET row_index = nextval('serial') - 1`);
         } catch (error) {
           console.error(error);
-          throw new Error('Error: can not import the arrow file to the database. Details: ' + error);
+          throw new Error(
+            'Error: can not import the arrow file to the database. Details: ' + error
+          );
         }
       }
       // close the connection

--- a/geoda-ai/src/hooks/use-duckdb.ts
+++ b/geoda-ai/src/hooks/use-duckdb.ts
@@ -225,12 +225,15 @@ export class DuckDB {
 
           // add a new column to the table for the row index
           await conn.query(`ALTER TABLE "${tableName}" ADD COLUMN row_index INTEGER DEFAULT 0`);
+          // drop the sequence if it exists
+          await conn.query('DROP SEQUENCE IF EXISTS serial');
           // generate an ascending sequence starting from 1
           await conn.query('CREATE SEQUENCE serial');
           // Use nextval to update the row_index column
           await conn.query(`UPDATE "${tableName}" SET row_index = nextval('serial') - 1`);
         } catch (error) {
           console.error(error);
+          throw new Error('Error: can not import the arrow file to the database. Details: ' + error);
         }
       }
       // close the connection


### PR DESCRIPTION
- Raise the table creation error, so the UI can catch it and display a warning message box instead of a hard crash
- A quick fix for a bug that the sequence need to be dropped if it exists when adding another dataset (creating another table) 